### PR TITLE
Disable default encryption on ONC profiles

### DIFF
--- a/www/profiles/onc/index.php
+++ b/www/profiles/onc/index.php
@@ -14,6 +14,5 @@ $basePath = '../..';
 
 $downloadKind = 'google-onc';
 $href = "${basePath}/profiles/onc/";
-$passphrase = $_COOKIE["${downloadKind}-download-passphrase"] ?: \substr( '000' . \random_int( 0, 9999 ), -4 );
 
 require \implode(\DIRECTORY_SEPARATOR, [\dirname(__DIR__), 'new', '_download.php']);


### PR DESCRIPTION
Our test-Chromebook fails importing encrypted profiles. When the issue is resolved, this commit may be reverted.